### PR TITLE
Update fabric connection module version to 0.4.0

### DIFF
--- a/examples/fabric-port-connection-with-zside-token/README.md
+++ b/examples/fabric-port-connection-with-zside-token/README.md
@@ -18,7 +18,7 @@ To provision this example, you should clone the github repository and run terraf
 
 ```bash
 git clone https://github.com/equinix-labs/terraform-equinix-fabric-connection-metal.git
-cd terraform-equinix-fabric-connection-metal/examples/network-edge-device-redundant-connection
+cd terraform-equinix-fabric-connection-metal/examples/fabric-port-connection-with-zside-token
 terraform init
 terraform apply
 ```
@@ -27,8 +27,8 @@ Note that this example may create resources which cost money. Run 'terraform des
 
 ## Variables
 
-See <https://registry.terraform.io/modules/equinix-labs/fabric-connection-metal/equinix/latest/examples/network-edge-device-redundant-connection?tab=inputs> for a description of all variables.
+See <https://registry.terraform.io/modules/equinix-labs/fabric-connection-metal/equinix/latest/examples/fabric-port-connection-with-zside-token?tab=inputs> for a description of all variables.
 
 ## Outputs
 
-See <https://registry.terraform.io/modules/equinix-labs/fabric-connection-metal/equinix/latest/examples/network-edge-device-redundant-connection?tab=outputs> for a description of all outputs.
+See <https://registry.terraform.io/modules/equinix-labs/fabric-connection-metal/equinix/latest/examples/fabric-port-connection-with-zside-token?tab=outputs> for a description of all outputs.

--- a/examples/fabric-port-connection/README.md
+++ b/examples/fabric-port-connection/README.md
@@ -13,7 +13,7 @@ To provision this example, you should clone the github repository and run terraf
 
 ```bash
 git clone https://github.com/equinix-labs/terraform-equinix-fabric-connection-metal.git
-cd terraform-equinix-fabric-connection-metal/examples/network-edge-device-redundant-connection
+cd terraform-equinix-fabric-connection-metal/examples/fabric-port-connection
 terraform init
 terraform apply
 ```
@@ -22,8 +22,8 @@ Note that this example may create resources which cost money. Run 'terraform des
 
 ## Variables
 
-See <https://registry.terraform.io/modules/equinix-labs/fabric-connection-metal/equinix/latest/examples/network-edge-device-redundant-connection?tab=inputs> for a description of all variables.
+See <https://registry.terraform.io/modules/equinix-labs/fabric-connection-metal/equinix/latest/examples/fabric-port-connection?tab=inputs> for a description of all variables.
 
 ## Outputs
 
-See <https://registry.terraform.io/modules/equinix-labs/fabric-connection-metal/equinix/latest/examples/network-edge-device-redundant-connection?tab=outputs> for a description of all outputs.
+See <https://registry.terraform.io/modules/equinix-labs/fabric-connection-metal/equinix/latest/examples/fabric-port-connection?tab=outputs> for a description of all outputs.

--- a/main.tf
+++ b/main.tf
@@ -61,7 +61,7 @@ module "equinix-fabric-connection" {
 module "equinix-fabric-connection-sec" {
   count   = var.service_token_automation_feature_preview && var.redundancy_type == "REDUNDANT" ? 1 : 0
   source  = "equinix-labs/fabric-connection/equinix"
-  version = "0.3.1"
+  version = "0.4.0"
 
   # required variables
   notification_users = var.fabric_notification_users


### PR DESCRIPTION
Note: In fabric connection modules for cloud providers all the connection logic happens in submodule `terraform-equinix-fabric-connection`, therefore user-agent will include the `terraform-equinix-fabric-connection` metadata module name and not `terraform-equinix-fabric-connection-metal` in this case. 